### PR TITLE
Ref page update - adds sections to reference page by category

### DIFF
--- a/docs/reference/api-FeatureExtractor.md
+++ b/docs/reference/api-FeatureExtractor.md
@@ -3,10 +3,7 @@ templateKey: "model-page"
 title: featureExtractor()
 exampleimgsrc: ../img/ref-featureextractor.png
 tags:
-  - image
-  - video
-  - text
-  - sound
+  - helpers
 
 description: >-
   You can use neural networks to recognize the content of images. Most of the time you will be using a "pre-trained" model trained on a large dataset to classify an image into a fixed set of categories. However you can also use a part of the pre-trained model: the [features](https://en.wikipedia.org/wiki/Feature_extraction). Those features allow you to 'retrain' or 'reuse' the model for a new custom task. This is known as [Transfer Learning](https://en.wikipedia.org/wiki/Transfer_learning).

--- a/docs/reference/api-ImageClassifier.md
+++ b/docs/reference/api-ImageClassifier.md
@@ -9,8 +9,6 @@ description: >-
 tags:
   - image
   - video
-  - text
-  - sound
 id: imageClassifier
 ---
 

--- a/docs/reference/api-KNNClassifier.md
+++ b/docs/reference/api-KNNClassifier.md
@@ -5,6 +5,11 @@ exampleimgsrc: ../img/ref-knnclassifier.png
 title: KNNClassifier()
 description: >-
   This class allows you to create a classifier using the K-Nearest Neighbors.
+tags:
+  - image
+  - video
+  - text
+  - sound
 ---
 
 This class allows you to create a classifier using the [K-Nearest Neighbors](https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm) algorithm. It's a little diffrent from other classes in this library, because it doesn't provide a model with weights, but rather a utility for constructing a KNN model using outputs from another model or any other data that could be classified.

--- a/docs/reference/api-KNNClassifier.md
+++ b/docs/reference/api-KNNClassifier.md
@@ -6,10 +6,7 @@ title: KNNClassifier()
 description: >-
   This class allows you to create a classifier using the K-Nearest Neighbors.
 tags:
-  - image
-  - video
-  - text
-  - sound
+  - helpers
 ---
 
 This class allows you to create a classifier using the [K-Nearest Neighbors](https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm) algorithm. It's a little diffrent from other classes in this library, because it doesn't provide a model with weights, but rather a utility for constructing a KNN model using outputs from another model or any other data that could be classified.

--- a/docs/reference/api-PitchDetection.md
+++ b/docs/reference/api-PitchDetection.md
@@ -5,6 +5,8 @@ exampleimgsrc: ../img/ref-pitchDetection.png
 title: pitchDetection()
 description: >-
   A pitch detection algorithm is a way of estimating the pitch or fundamental frequency of an audio signal.
+tags:
+  - sound
 ---
 
 A pitch detection algorithm is a way of estimating the pitch or fundamental frequency of an audio signal. This method allows to use a pre-trained machine learning pitch detection model to estimate the pitch of sound file.

--- a/docs/reference/api-Pix2Pix.md
+++ b/docs/reference/api-Pix2Pix.md
@@ -9,8 +9,6 @@ description: >-
 tags:
   - image
   - video
-  - text
-  - sound
 id: Pix2Pix
 
 ---

--- a/docs/reference/api-PoseNet.md
+++ b/docs/reference/api-PoseNet.md
@@ -5,6 +5,9 @@ exampleimgsrc: ../img/ref-posenet.png
 title: poseNet()
 description: >-
   PoseNet is a machine learning model that allows for Real-time Human Pose Estimation.
+tags:
+  - image
+  - video
 ---
 
 PoseNet is a machine learning model that allows for [Real-time Human Pose Estimation](https://medium.com/tensorflow/real-time-human-pose-estimation-in-the-browser-with-tensorflow-js-7dd0bc881cd5).

--- a/docs/reference/api-SketchRNN.md
+++ b/docs/reference/api-SketchRNN.md
@@ -5,6 +5,9 @@ exampleimgsrc: ../img/ref-sketchrnn.png
 title: SketchRNN()
 description: >-
   The SketchRNN model can create new drawings (from a list of categories) based on an initial path.
+tags:
+  - image
+  - text
 ---
 
 SketchRNN is a recurrent neural network model trained on millions of doodles collected from the [Quick, Draw! game](https://quickdraw.withgoogle.com/). The SketchRNN model can create new drawings (from a list of categories) based on an initial path.

--- a/docs/reference/api-StyleTransfer.md
+++ b/docs/reference/api-StyleTransfer.md
@@ -5,6 +5,9 @@ exampleimgsrc: ../img/ref-styletransfer.png
 title: styleTransfer()
 description: >-
   Style Transfer is a machine learning technique that allows to transfer the style of one image into another one. This is a two step process, first you need to train a model on one particular style and then you can apply this style to another image.
+tags:
+  - image
+  - video
 ---
 
 Style Transfer is a machine learning technique that allows to transfer the style of one image into another one. This is a two step process, first you need to train a model on one particular style and then you can apply this style to another image.

--- a/docs/reference/api-Word2vec.md
+++ b/docs/reference/api-Word2vec.md
@@ -5,6 +5,8 @@ exampleimgsrc: ../img/ref-word2vec.png
 title: word2vec()
 description: >-
   Word2vec is a group of related models that are used to produce word embeddings. This method allows you to perform vector operations on a given set of input vectors.
+tags:
+  - text
 ---
 
 Word2vec is a group of related models that are used to produce [word embeddings](https://en.wikipedia.org/wiki/Word2vec)</sup>. This method allows you to perform vector operations on a given set of input vectors.

--- a/docs/reference/api-YOLO.md
+++ b/docs/reference/api-YOLO.md
@@ -5,6 +5,9 @@ exampleimgsrc: ../img/ref-yolo.png
 title: YOLO()
 description: >- 
   YOLO (You only look once) is a state-of-the-art, real-time object detection system.
+tags:
+  - image
+  - video
 ---
 
 You only look once ([YOLO](https://pjreddie.com/darknet/yolo/)) is a state-of-the-art, real-time object detection system.

--- a/docs/reference/api-charRNN.md
+++ b/docs/reference/api-charRNN.md
@@ -3,10 +3,7 @@ templateKey: "model-page"
 title: CharRNN()
 exampleimgsrc: ../img/ref-charRnn.png
 tags:
-  - image
-  - video
   - text
-  - sound
 
 description: >-
   RNN and [LSTMs](https://colah.github.io/posts/2015-08-Understanding-LSTMs/) (Long Short Term Memory networks) are a type of Neural Network architecture useful for working with sequential data (like characters in text or the musical notes of a song) where the order of the that sequence matters. This class allows you run a model pre-trained on a body of text to generate new text.

--- a/docs/reference/example.md
+++ b/docs/reference/example.md
@@ -2,10 +2,9 @@
 templateKey: "model-page"
 title: example()
 tags:
-  - image
-  - video
-  - text
-  - sound
+  - tag1
+  - tag2
+  - tag3
 
 description: >-
   RNN and [LSTMs](https://colah.github.io/posts/2015-08-Understanding-LSTMs/) (Long Short Term Memory networks) are a type of Neural Network architecture useful for working with sequential data (like characters in text or the musical notes of a song) where the order of the that sequence matters. This class allows you run a model pre-trained on a body of text to generate new text.

--- a/src/components/ModelListCards.js
+++ b/src/components/ModelListCards.js
@@ -1,6 +1,47 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link, graphql, StaticQuery } from "gatsby";
+import { tag } from "postcss-selector-parser";
+
+
+function displaySectionByTag(models, tag){
+    if(!models) return ""
+
+    const selected = models.filter( ({ node: model }) => model.frontmatter.tags.includes(tag));
+
+    return (
+        <section id={`section-${tag}`}>
+            <h2 style={{fontSize:"28px"}}>{tag}</h2>
+            <ul className="ModelList">
+            {selected.map(({ node: model }) => (
+                <li style={{padding:"0.5rem"}} className="ModelList__item" key={model.id}>
+                <div style={{border:"1px solid #D8D8D8", padding:"0.5rem",  borderRadius:"2px"}}>
+                <div className="ModelList__title">
+                    <Link
+                    activeClassName="ModelList__link--active"
+                    to={model.fields.slug}
+                    >
+                    {model.frontmatter.title}
+                    </Link>
+                </div>
+                <div style={{width:"100%", 
+                padding:"none"}}>
+                    <img alt={model.frontmatter.description || "tbd"} style={{border:"0px solid black", width:"100%", height:"100%"}} 
+                    src={model.frontmatter.exampleimgsrc || "../img/logo-purple-circle.png"}/>
+                </div>
+                </div>
+                </li>
+            ))}
+        </ul>
+        </section>
+    )
+
+}
+
+const aTagRefStyle = {
+    textDecoration:'underline',
+    padding:"1rem 1rem 1rem 0rem"
+}
 
 class ModelListCards extends React.Component {
   render() {
@@ -8,27 +49,21 @@ class ModelListCards extends React.Component {
     const { edges: models } = data.allMarkdownRemark;
 
     return (
-      <ul className="ModelList">
-        {models &&
-          models.map(({ node: model }) => (
-            <li className="ModelList__item" key={model.id}>
-              <div className="ModelList__title">
-                <Link
-                  activeClassName="ModelList__link--active"
-                  to={model.fields.slug}
-                >
-                  {model.frontmatter.title}
-                </Link>
-              </div>
-              <div style={{width:"200px", 
-            height:"200px", 
-            padding:"1rem"}}>
-                <img alt={model.frontmatter.description || "tbd"} style={{border:"2px solid black", width:"100%", height:"100%"}} 
-                src={model.frontmatter.exampleimgsrc || "../img/logo-purple-circle.png"}/>
-            </div>
-            </li>
-          ))}
-      </ul>
+        <div>
+        <p>Welcome to the ml5.js reference page! Here you can browse the various categories of functionality that ml5.js provides. We have categorized the functionality of ml5.js based on the types of input and output that you might be interested to work with.</p>
+        <h3>We currently have 4 categories:
+        <ul style={{display:"flex", flexDirection:"row", justifyContent:"flex-start", width: "100%"}}>
+            <a style={aTagRefStyle} href="#section-image">Image</a>
+            <a style={aTagRefStyle} href="#section-sound">Sound</a>
+            <a style={aTagRefStyle} href="#section-text">Text</a> 
+            <a style={aTagRefStyle} href="#section-helpers">Helpers</a>
+        </ul>
+        </h3>
+        { displaySectionByTag(models, 'image')}
+        { displaySectionByTag(models, 'sound')}
+        { displaySectionByTag(models, 'text')}
+        { displaySectionByTag(models, 'helpers')}
+        </div>
     );
   }
 }
@@ -62,6 +97,7 @@ export default () => (
                 date(formatString: "MMMM DD, YYYY")
                 featuredpost
                 exampleimgsrc
+                tags
               }
             }
           }


### PR DESCRIPTION
Hi! 

This is a proposition to address the creation of categories for ml5 functionality on the ml5 reference page.  Ref, this discussion here: https://github.com/ml5js/ml5-website-2/pull/11#issuecomment-490924493

In this proposition, I created 4 categories:
* Image
* Text
* Sound
* Helpers

The relevant features are then grouped into these respective sections based on tags and displayed as such. 

A note on code: please excuse sloppiness - I will clean up the inline styles if/when we decide to move forward with the proposals :) Thanks for understanding!

## Proposed changes:
![Screenshot_2019-05-09 ml5js·Friendly Machine Learning For The Web(8)](https://user-images.githubusercontent.com/3622055/57481053-41a85d00-726f-11e9-9c5a-c3066e1f94f8.png)
