### PR TITLE
add optional training & tutorial tab, fix #14 , fix small a11y issues

### DIFF
--- a/docs/community/2019-02-12-stefania-druga-on-smart-toys.md
+++ b/docs/community/2019-02-12-stefania-druga-on-smart-toys.md
@@ -5,6 +5,7 @@ author: ml5 community
 description: In Conversation with ITP SIR Stefania Druga
 featuredimage: ../assets/community-stefania-druga-on-smart-toys.png
 externalLink: https://medium.com/@ml5js/the-hard-fun-of-designing-alternatives-to-smart-toys-dd72da1c6de8
+# externalLink: null
 featuredpost: false
 date: 2019-02-12T15:04:10.000Z
 tags:

--- a/docs/reference/example.md
+++ b/docs/reference/example.md
@@ -82,6 +82,9 @@ examples:
       yolo.detect(function(err, results) {
         console.log(results); // Will output bounding boxes of detected objects
       });
+
+tutorials: ""
+training: ""
 ---
 
 ## Syntax ( A subject should use H2 )

--- a/src/components/BlogRoll.js
+++ b/src/components/BlogRoll.js
@@ -59,7 +59,7 @@ class BlogRoll extends React.Component {
                         rel="noopener noreferrer"
                       >
                         Launch Experiments{" "}
-                        <span role="img" aria-tag="rocket">
+                        <span role="img" aria-label="rocket">
                           {" "}
                           🚀
                         </span>
@@ -67,7 +67,7 @@ class BlogRoll extends React.Component {
                     ) : (
                       <Link className="Post__link" to={post.fields.slug}>
                         Keep Reading
-                        <span role="img" aria-tag="reading">
+                        <span role="img" aria-label="reading">
                           {" "}
                           👓
                         </span>

--- a/src/scss/components/_Tab.scss
+++ b/src/scss/components/_Tab.scss
@@ -9,6 +9,7 @@ $border-width: 1px;
   margin: calc(2 * #{$gutter}) 0 $gutter 0 !important;
   padding: 0 $gutter 0 $gutter !important;
   color: $secondary-font-color;
+  display: flex;
 
   @include referenceBreakpoint() {
     padding: 0 !important;
@@ -17,6 +18,7 @@ $border-width: 1px;
 
 .react-tabs__tab {
   display: inline-block;
+  flex-grow: 1;
   border: $border-width solid transparent !important;
   border-bottom: none !important;
   bottom: calc(-1 * #{$border-width}) !important;

--- a/src/templates/community-post.js
+++ b/src/templates/community-post.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { kebabCase } from "lodash";
+// import { kebabCase } from "lodash";
 import Helmet from "react-helmet";
-import { graphql, Link } from "gatsby";
+import { graphql } from "gatsby";
 import Layout from "../components/Layout";
 import Content, { HTMLContent } from "../components/Content";
 

--- a/src/templates/model-page.js
+++ b/src/templates/model-page.js
@@ -9,6 +9,7 @@ import ModelList from "../components/ModelList";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import MarkdownContent from "../components/MarkdownContent";
 import Highlight from "react-highlight.js";
+
 export const ModelPageTemplate = ({
   content,
   contentComponent,
@@ -16,6 +17,8 @@ export const ModelPageTemplate = ({
   tags,
   title,
   examples,
+  tutorials,
+  training,
   helmet
 }) => {
   const PostContent = contentComponent || Content;
@@ -43,8 +46,8 @@ export const ModelPageTemplate = ({
           <TabList>
             <Tab>documentation</Tab>
             <Tab>examples</Tab>
-            <Tab>tutorial</Tab>
-            <Tab>advanced</Tab>
+            {tutorials ? <Tab>tutorial</Tab> : null}
+            {training ? <Tab>training</Tab> : null}
           </TabList>
 
           <TabPanel>
@@ -72,20 +75,22 @@ export const ModelPageTemplate = ({
                       }}
                     />
                     <MarkdownContent content={example.demo} />
-                    <script>console.log("XXX")</script>
                     <Highlight language="javascript">{example.code}</Highlight>
                   </div>
                 ))
               : null}
           </TabPanel>
+          {tutorials ? (
+            <TabPanel>
+              <h2>Tutorial</h2>
+            </TabPanel>
+          ) : null}
 
-          <TabPanel>
-            <h2>Tutorial</h2>
-          </TabPanel>
-
-          <TabPanel>
-            <h2>Advanced</h2>
-          </TabPanel>
+          {training ? (
+            <TabPanel>
+              <h2>Training</h2>
+            </TabPanel>
+          ) : null}
         </Tabs>
       </div>
     </article>
@@ -135,6 +140,8 @@ const ModelPage = ({ data }) => {
             tags={post.frontmatter.tags}
             title={post.frontmatter.title}
             examples={post.frontmatter.examples}
+            tutorials={post.frontmatter.tutorials}
+            training={post.frontmatter.training}
           />
         </div>
       </section>
@@ -164,6 +171,8 @@ export const pageQuery = graphql`
           demo
           code
         }
+        tutorials
+        training
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fix empty tabs #14, now tutorial and training tab only show when they have content
Fix small a11y errors, according to es-lint info:
change emoji `aria-tag` to `aria-label`, it's a typo I created before

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
In reference page front matter:
use `tutorials: "the content of tutorials"` to add content and turn on the tutorial tab
use `training: "the content of training"` to add content and turn on the training tab

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
