### PR TITLE
comments out MarkdownContent component for rendering examples

### DIFF
--- a/src/templates/model-page.js
+++ b/src/templates/model-page.js
@@ -74,7 +74,7 @@ export const ModelPageTemplate = ({
                         __html: example.demo
                       }}
                     />
-                    <MarkdownContent content={example.demo} />
+                    {/* <MarkdownContent content={example.demo} /> */}
                     <Highlight language="javascript">{example.code}</Highlight>
                   </div>
                 ))


### PR DESCRIPTION
For now, this comments out for rendering examples. We choose to directly inject html rather than converting markdown to html. We can change our mind later if we want.

```js
{/* <MarkdownContent content={example.demo} /> */}
```
