### PR TITLE
filter out example page reference from references

### DIFF
--- a/docs/reference/example.md
+++ b/docs/reference/example.md
@@ -3,10 +3,7 @@ templateKey: "model-page"
 title: example()
 exampleimgsrc: ../assets/ref-yolo.png
 tags:
-  - image
-  - text
-  - helpers
-  - sound
+  - reference
 
 description: >-
   RNN and [LSTMs](https://colah.github.io/posts/2015-08-Understanding-LSTMs/) (Long Short Term Memory networks) are a type of Neural Network architecture useful for working with sequential data (like characters in text or the musical notes of a song) where the order of the that sequence matters. This class allows you run a model pre-trained on a body of text to generate new text.
@@ -79,6 +76,16 @@ training: >
 >
 > - `model`, **model** (props use strong or inline block inside a list item, which is purple): The pre-trained charRNN model.
 > - **callback** — Optional. A callback to be called once the model has loaded. If no callback is provided, it will return a promise that will be resolved once the model has loaded.
+
+Tags in the front matter can be formatted as such:
+
+```
+tags:
+ - image
+ - text
+ - helpers
+ - sound
+```
 
 ## Properties
 

--- a/src/components/ModelList.js
+++ b/src/components/ModelList.js
@@ -7,10 +7,14 @@ class ModelList extends React.Component {
     const { data } = this.props;
     const { edges: models } = data.allMarkdownRemark;
 
+    const modelsFiltered = models.filter( ({ node: model }) => {
+      return !model.frontmatter.tags.includes('reference')
+    })
+
     return (
       <ul className="ModelList">
-        {models &&
-          models.map(({ node: model }) => (
+        {modelsFiltered &&
+          modelsFiltered.map(({ node: model }) => (
             <li className="ModelList__item" key={model.id}>
               <div className="ModelList__title">
                 <Link
@@ -55,6 +59,7 @@ export default () => (
                 templateKey
                 date(formatString: "MMMM DD, YYYY")
                 featuredpost
+                tags
               }
             }
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Adds a filter function to remove the "example" page from the references. The example page is tagged with "reference" as a way to filter out this page from view.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Changes the view to remove the example page that is just for reference.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No it should not. 

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

We need to make all the docs consistent in style. Is the example() page the source of style truth? If so, then we should change the style of the rest of the docs. If not, then we should update the example to reflect what we want to be the source of truth. 

Since the example page is distracting, This PR filters out the example page from view.