### PR TITLE
Corrected all the broken links

### DIFF
--- a/docs/reference/api-KNNClassifier.md
+++ b/docs/reference/api-KNNClassifier.md
@@ -202,7 +202,9 @@ This class allows you to create a classifier using the [K-Nearest Neighbors](htt
 
 For example, you could get features of an image by calling `FeatureExtractor.infer()`, and feed the features to KNNClassifier to classify an image.
 
-You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](/docs/knnclassifier-posenet) that uses KNNClassifier to classify data from [PoseNet](/docs/PoseNet) model.
+You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](https://github.com/ml5js/ml5-examples/tree/release/p5js/KNNClassification/KNNClassification_PoseNet
+
+) that uses KNNClassifier to classify data from [PoseNet](https://ml5js.org/reference/api-PoseNet/) model.
 
 ## Example
 

--- a/docs/reference/api-PoseNet.md
+++ b/docs/reference/api-PoseNet.md
@@ -141,7 +141,7 @@ poseNet.on("pose", function(results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/PoseNet/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_webcam) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-SketchRNN.md
+++ b/docs/reference/api-SketchRNN.md
@@ -124,7 +124,7 @@ function gotSketch(err, result) {
 }
 ```
 
-Here is [a complete example](https://github.com/ml5js/ml5-examples/blob/master/p5js/SketchRNN/sketch.js).
+Here is [a complete example](https://github.com/ml5js/ml5-examples/tree/release/p5js/SketchRNN/SketchRNN_basic).
 
 ## Syntax
 

--- a/docs/reference/api-StyleTransfer.md
+++ b/docs/reference/api-StyleTransfer.md
@@ -72,7 +72,7 @@ tutorials:
 
 Style Transfer is a machine learning technique that allows to transfer the style of one image into another one. This is a two step process, first you need to train a model on one particular style and then you can apply this style to another image.
 
-You can train your own images following [this tutorial](/docs/training-styletransfer).
+You can train your own images following [this tutorial](https://github.com/ml5js/training-styletransfer).
 
 This implementation is heavily based on [fast-style-transfer-deeplearnjs](https://github.com/reiinakano/fast-style-transfer-deeplearnjs) by [Reiichiro Nakano](https://github.com/reiinakano).
 The [original TensorFlow implementation](https://github.com/lengstrom/fast-style-transfer) was developed by [Logan Engstrom](https://github.com/lengstrom)

--- a/docs/reference/api-Word2vec.md
+++ b/docs/reference/api-Word2vec.md
@@ -82,7 +82,7 @@ examples:
 
 Word2vec is a group of related models that are used to produce [word embeddings](https://en.wikipedia.org/wiki/Word2vec)</sup>. This method allows you to perform vector operations on a given set of input vectors.
 
-You can use the word models [we provide](https://github.com/ml5js/ml5-examples/tree/master/p5js/Word2Vec/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/ml5-data-and-training/tree/master/training). More of this soon!
+You can use the word models [we provide](https://github.com/ml5js/ml5-examples/tree/master/p5js/Word2Vec/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/training-word2vec). More of this soon!
 
 ### Example
 

--- a/docs/reference/api-YOLO.md
+++ b/docs/reference/api-YOLO.md
@@ -100,7 +100,7 @@ yolo.detect(function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/YOLO/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/YOLO) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-charRNN.md
+++ b/docs/reference/api-charRNN.md
@@ -13,7 +13,7 @@ description: >-
   <br />
   <br />
 
-  You can train your own models [using this tutorial](/docs/training-lstm) or use [this set of pre trained models](https://github.com/ml5js/ml5-data-and-training/tree/master/models/lstm).
+  You can train your own models [using this tutorial](https://github.com/ml5js/training-lstm) or use [this set of pre trained models](https://github.com/ml5js/ml5-data-and-training/tree/master/models/lstm).
 
 examples:
   - title: CharRNN Text Generator Example
@@ -121,7 +121,7 @@ rnn.generate({ seed: "the meaning of pizza is" }, function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/LSTM/LSTM_Text/sketch.js) is a complete example using the [p5.js](https://p5js.org) library.
+[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/CharRNN/CharRNN_Text) is a complete example using the [p5.js](https://p5js.org) library.
 
 ## Syntax
 


### PR DESCRIPTION
There were a few broken links in reference docs which needs to be corrected because it was leaving the users bamboozled as the links were not working properly. As mentioned in this issue #116  all the broken links are now changed with the new ones and they are up and running. 


**What kind of change does this PR introduce?**

BugFix


**Does this PR introduce a breaking change?**
No


**What needs to be documented once your changes are merged?**
All the changes were to correct the website reference documentation no other documentation is required for these changes.
