### PR TITLE
Redirects reference and getting started to ml5 docsify page

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -72,7 +72,7 @@ const Navbar = class extends React.Component {
               <a
                 className="Navbar__item"
                 activeClassName="is-active"
-                href="https://ml5js.github.io/ml5-library/docs/#/"
+                href="https://ml5js.github.io/ml5-library/docs/#/reference/index"
               >
                 Reference
               </a>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -62,20 +62,20 @@ const Navbar = class extends React.Component {
             className={`Navbar__menu ${this.state.navBarActiveClass}`}
           >
             <div className="Navbar__itemContainer">
-              <Link
+              <a
                 className="Navbar__item"
                 activeClassName="is-active"
-                to="/getting-started/"
+                href="https://ml5js.github.io/ml5-library/docs/#/"
               >
                 Getting Started
-              </Link>
-              <Link
+              </a>
+              <a
                 className="Navbar__item"
                 activeClassName="is-active"
-                to="/reference/"
+                href="https://ml5js.github.io/ml5-library/docs/#/"
               >
                 Reference
-              </Link>
+              </a>
               <Link
                 className="Navbar__item"
                 activeClassName="is-active"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

* This PR is about redirecting users to the ml5 docsify documentation page
* The idea is to move the documentation closer to the ml5-library to make it easier to keep up to date. 
* Here, users will click on the top nav bar and be taken to a separate ml5 documentation page.

Note: @shiffman - we should consider adding a subdomain to the ml5-library: e.g.
`https://docs.ml5js.org` or `learn.ml5js.org`

For now, the docs are located at:
https://ml5js.github.io/ml5-library/docs/#/

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

* refactoring

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

* No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

