### PR TITLE
Replace website version details with a badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,6 @@
 ---
 templateKey: home-page
-title: Friendly Machine Learning for the Web.
-description: >-
-  The library is supported by code examples, tutorials, and sample datasets with an emphasis on ethical computing.
-  Bias in data, stereotypical harms, and responsible crowdsourcing are part of the documentation around data collection
-  and usage.
 
-image: ./assets/itay-banner.jpg
 heading: Friendly Machine Learning for the Web
 subheading: A neighborly approach to creating and exploring artificial intelligence in the browser.
 
@@ -29,21 +23,6 @@ intro:
       text: >
         ml5.js aims to support broader public understanding of machine learning and foster deeper engagement with ethical computing, responsible data collection, and accessiblity and diversity of people and perspectives in technology and the arts.
 
-version:
-  heading: Build tools using easy classification systems with tons of **pre trained models**!
-  recent: "Current version: 0.4.3  Last update: 04 November 2019"
-  snippet: >
-    const pix2pix = ml5.pix2pix('models/customModel.pict', modelLoaded);
-
-    function modelLoaded() {
-      console.log('Model Loaded!');
-    }
-
-    // Transfer using a canvas
-    pix2pix.transfer(canvas, function(err, result) {
-      console.log(result);
-    });
-
 model:
   blurbs:
     - image: ./assets/ref-posenet.png
@@ -54,13 +33,13 @@ model:
         YOLO (You only look once) is a state-of-the-art, real-time object detection and classification system.
     - image: ./assets/ref-styletransfer.png
       text: >
-        pix2pix is image-to-image translation with conditional adversarial networks. 
+        pix2pix is image-to-image translation with conditional adversarial networks.
     - image: ./assets/ref-classification.png
       text: >
-        Classify the content of images with pre-trained models. 
+        Classify the content of images with pre-trained models.
     - image: ./assets/ref-sketchrnn.png
       text: >
-        Generate new doodles with a neural network based on Google's Quick Draw. 
+        Generate new doodles with a neural network based on Google's Quick Draw.
   heading: Discover the creative possibilities of machine learning!
 
 team:
@@ -76,10 +55,10 @@ Last update: 04, November 2019
 
 ```javascript
 // Step 1: Create an image classifier with MobileNet
-const classifier = ml5.imageClassifier('MobileNet', onModelReady);
+const classifier = ml5.imageClassifier("MobileNet", onModelReady);
 
 // Step 2: select an image
-const img = document.querySelector("#myImage")
+const img = document.querySelector("#myImage");
 
 // Step 3: Make a prediction
 let prediction = classifier.predict(img, gotResults);
@@ -88,6 +67,5 @@ let prediction = classifier.predict(img, gotResults);
 function gotResults(err, results) {
   console.log(results);
   // all the amazing things you'll add
-
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,7 @@ team:
 
 ## ml5.js provides an approachable API and examples to help you get started
 
-Current version: 0.4.3
-Last update: 04, November 2019
+![npm](https://img.shields.io/npm/v/ml5?color=%230ace81&label=Latest%20Version)
 
 ```javascript
 // Step 1: Create an image classifier with MobileNet

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -8,43 +8,53 @@ import Features from "../components/Features";
 
 export const HomePageTemplate = ({
   content,
-  image,
-  title,
   heading,
-  featureheading,
   subheading,
   mainpitch,
-  description,
   intro,
-  version,
   model,
   team
 }) => (
   <div className="ml5Grid__container--homePage">
     <section
       className="circles-1"
-      style={{display:"flex", 
-      flexDirection:"column", 
-      justifyContent:"center",
-      alignItems:"center"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center"
       }}
     >
       <div className="home__overlay" />
-      <Link style={{zIndex:"9"}} to="">
+      <Link style={{ zIndex: "9" }} to="">
         {/* heading */}
-        <h2 style={{width:"100%", 
-        maxWidth:"680px", 
-        fontSize:"4rem", 
-        color:"#a15ffb",
-        backgroundColor:"white",
-        textAlign:"center"}} className="home__heading">{heading}</h2>
+        <h2
+          style={{
+            width: "100%",
+            maxWidth: "680px",
+            fontSize: "4rem",
+            color: "#a15ffb",
+            backgroundColor: "white",
+            textAlign: "center"
+          }}
+          className="home__heading"
+        >
+          {heading}
+        </h2>
         {/* subheading */}
-        <p style={{width:"100%", 
-        maxWidth:"680px", 
-        fontSize:"1.5rem", 
-        color:"#a15ffb",
-        backgroundColor:"white",
-        textAlign:"center"}} className="home__subheading">{subheading}</p>
+        <p
+          style={{
+            width: "100%",
+            maxWidth: "680px",
+            fontSize: "1.5rem",
+            color: "#a15ffb",
+            backgroundColor: "white",
+            textAlign: "center"
+          }}
+          className="home__subheading"
+        >
+          {subheading}
+        </p>
       </Link>
     </section>
 
@@ -115,15 +125,10 @@ const HomePage = ({ data }) => {
     <Layout>
       <HomePageTemplate
         content={content}
-        image={frontmatter.image}
-        title={frontmatter.title}
         heading={frontmatter.heading}
-        featureheading={frontmatter.featureheading}
         subheading={frontmatter.subheading}
         mainpitch={frontmatter.mainpitch}
-        description={frontmatter.description}
         intro={frontmatter.intro}
-        version={frontmatter.version}
         model={frontmatter.model}
         team={frontmatter.team}
       />
@@ -146,14 +151,6 @@ export const pageQuery = graphql`
     markdownRemark(frontmatter: { templateKey: { eq: "home-page" } }) {
       html
       frontmatter {
-        title
-        image {
-          childImageSharp {
-            fluid(maxWidth: 2048, quality: 100) {
-              ...GatsbyImageSharpFluid
-            }
-          }
-        }
         heading
         subheading
 
@@ -161,7 +158,7 @@ export const pageQuery = graphql`
           title
           description
         }
-        description
+
         intro {
           blurbs {
             image {
@@ -173,11 +170,6 @@ export const pageQuery = graphql`
             }
             text
           }
-        }
-        version {
-          heading
-          recent
-          snippet
         }
 
         model {
@@ -193,6 +185,7 @@ export const pageQuery = graphql`
           }
           heading
         }
+
         team {
           image {
             childImageSharp {

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -46,10 +46,6 @@ export const HomePageTemplate = ({
         backgroundColor:"white",
         textAlign:"center"}} className="home__subheading">{subheading}</p>
       </Link>
-
-      {/* <Link to="">
-        <h2 className="home__featuredTitle">{featureheading}</h2>
-      </Link> */}
     </section>
 
     <section className="home__container home__gridContainer">


### PR DESCRIPTION
## PR Details
**What kind of change does this PR introduce?**

This PR introduces changes to represent the version of ML5 using a badge from Shields.io (see all templates [here](https://shields.io/category/version)) instead of a hardcoded version number. This helps make it easier to release new versions of the library because we no longer need to manually update the website after every release. 

Typically, the process for updating the version would be to:
- Create a new branch off of the master branch named after the new version number
- In the new branch, manually change the static references to the core library version to the latest version and then commit the changes (Example PR)
- Merge the changes into master, which triggers a deployment to Netlify.

After these changes are merged, no steps will be required to update the website!

The tradeoff here is that we no longer show the most recent release date because Shields.io, unfortunately, doesn't handle versions for NPM releases. We could set this up later if we ever support GitHub release, though (see GitHub templates [here](https://shields.io/category/activity)).


**Does this PR introduce a breaking change?**
Nope! Though there are some cleanup changes included in this PR to remove unused fields.

**What needs to be documented once your changes are merged?**
I don't believe that there are any necessary documentation changes.

## Images
Before
![Screen Shot 2020-03-03 at 4 03 15 PM](https://user-images.githubusercontent.com/6589909/75819339-835b4480-5d68-11ea-9a33-783995e2e9e1.png)

After
![Screen Shot 2020-03-03 at 4 03 55 PM](https://user-images.githubusercontent.com/6589909/75819401-9cfc8c00-5d68-11ea-953e-3971ae4bcccf.png)

