### PR TITLE
Update references to ml5-examples repo

### DIFF
--- a/docs/getting-started/hello-ml5.md
+++ b/docs/getting-started/hello-ml5.md
@@ -50,7 +50,7 @@ Your project directory should look something like this:
 
 ## Demo
 
-This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-examples/tree/release/javascript/ImageClassification).
+This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-library/tree/development/examples/javascript/ImageClassification).
 
 <br/>
 
@@ -207,7 +207,7 @@ Some guiding questions you might start to think about are:
 1. When classifying an image with MobileNet, does the computer see people? If not, why do you think that is?
 2. Do you notice that MobileNet is better at classifying some animals over others? Why do you think that is?
 
-## [Source](https://github.com/ml5js/ml5-examples/tree/master/p5js/ImageClassification/ImageClassification)
+## [Source](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification)
 
-- [ml5.js image classification on Github](https://github.com/ml5js/ml5-examples/tree/master/p5js/ImageClassification/ImageClassification)
+- [ml5.js image classification on Github](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification)
 - [ml5.js image classification on p5 web editor](https://editor.p5js.org/ml5/sketches/ImageClassification)

--- a/docs/getting-started/running-examples.md
+++ b/docs/getting-started/running-examples.md
@@ -12,37 +12,27 @@ If you've looked at our [quickstart](/getting-started/) and [introduction to ml5
 
 <br/>
 
-A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples at out Github page: [ml5-examples](https://github.com/ml5js/ml5-examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them. 
+A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples at our [GitHub page](https://github.com/ml5js/ml5-library/tree/development/examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them. 
 
 You can check out all the examples running:
-> - [on this massive list](https://github.com/ml5js/ml5-examples#examples-index)
+> - [on this massive list](https://github.com/ml5js/ml5-library/tree/development/examples#examples-index)
 > - [on the p5 web editor](https://editor.p5js.org/ml5/sketches)
 
-If you'd like to download the examples and run them locally, download the [ml5-examples github repo](https://github.com/ml5js/ml5-examples) and run a local web server at the root directory (if this sentence sounds foreign to you, see the How-To section below). The fastest way to do this is:
+If you'd like to download the examples and run them locally, download the [ml5-library github repo](https://github.com/ml5js/ml5-library) and run the scripts for building and serving the examples (if this sentence sounds foreign to you, see the How-To section below). The fastest way to do this is:
 
 <br/>
 
-with **python3** installed on your computer:
+with **Node.js** installed on your computer:
 ```bash
-cd /path/to/ml5-examples
-python -m http.server 8081
+cd /path/to/ml5-library
+npm install
+npm run examples:build
+npm run examples:serve
 ```
 
-<br/>
-
-with **python2.7** installed on your computer:
-
-```bash
-cd /path/to/ml5-examples
-python -m SimpleHTTPServer 8081
-```
-
-Then open up your web browser to the url: **localhost:8081** 
+Then open up your web browser to the url: **localhost:8080** 
 
 <br/>
-
-Here we set the port number to **8081**, but you can change the port number to something else like **3000** (then: **localhost:3030**), **3001** (then: **localhost:3031**) for example. 
-
 
 ## How to: Run examples and develop "locally"
 

--- a/docs/reference/api-BodyPix.md
+++ b/docs/reference/api-BodyPix.md
@@ -11,7 +11,7 @@ order: 2
 
 examples:
   - title: BodyPix Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/BodyPix
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/BodyPix
     demo: https://ml5js.github.io/ml5-examples/p5js/BodyPix/BodyPix_Webcam/
     code: >-
       let bodypix;

--- a/docs/reference/api-CVAE.md
+++ b/docs/reference/api-CVAE.md
@@ -11,7 +11,7 @@ order: 6
 
 examples:
   - title: CVAE using Quickdraw dataset
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/CVAE
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CVAE/CVAE_QuickDraw
     demo: https://ml5js.github.io/ml5-examples/p5js/CVAE/
     code: >-
       let cvae;

--- a/docs/reference/api-DCGAN.md
+++ b/docs/reference/api-DCGAN.md
@@ -11,7 +11,7 @@ order: 7
 
 examples:
   - title: DCGAN - generated lo-res aerial images
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/DCGAN
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/DCGAN
     demo: https://ml5js.github.io/ml5-examples/p5js/DCGAN/
     code: >-
       let dcgan;

--- a/docs/reference/api-FeatureExtractor.md
+++ b/docs/reference/api-FeatureExtractor.md
@@ -16,7 +16,7 @@ description: >-
 
 examples:
   - title: Feature Extractor for Image Classification
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
     demo: https://ml5js.github.io/ml5-examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
     code: >-  
       let featureExtractor;
@@ -165,9 +165,9 @@ classifier.classify(document.getElementById("dogB"), function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js) is a complete example to create a custom regression.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js) is a complete example to create a custom regression.
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js) is a complete example to create a custom classifier.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js) is a complete example to create a custom classifier.
 
 ### Syntax
 

--- a/docs/reference/api-ImageClassifier.md
+++ b/docs/reference/api-ImageClassifier.md
@@ -14,7 +14,7 @@ order: 0
 
 examples:
   - title: Image classifier on image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ImageClassification/ImageClassification
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification
     demo: https://ml5js.github.io/ml5-examples/p5js/ImageClassification/ImageClassification
     code: >-
       // Initialize the Image Classifier method with MobileNet. A callback needs to be passed.
@@ -50,7 +50,7 @@ examples:
       }
 
   - title: Image classifier on video
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ImageClassification/ImageClassification_Video
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ImageClassification/ImageClassification_Video
     demo: https://ml5js.github.io/ml5-examples/p5js/ImageClassification/ImageClassification_Video
     code: >-
       let classifier;
@@ -112,7 +112,7 @@ classifier.predict(document.getElementById('image'), function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/ImageClassification/ImageClassification/sketch.js) is a complete example using the [p5.js](https://p5js.org/) library for loading and displaying the image.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/ImageClassification/ImageClassification/sketch.js) is a complete example using the [p5.js](https://p5js.org/) library for loading and displaying the image.
 
 ## Syntax
   ```javascript

--- a/docs/reference/api-KNNClassifier.md
+++ b/docs/reference/api-KNNClassifier.md
@@ -11,7 +11,7 @@ order: 1
 
 examples:
   - title: KNN Classfication on video
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/KNNClassification/KNNClassification_Video
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_Video
     demo: https://ml5js.github.io/ml5-examples/p5js/KNNClassification/KNNClassification_Video
     code: >-
       let video;
@@ -202,9 +202,7 @@ This class allows you to create a classifier using the [K-Nearest Neighbors](htt
 
 For example, you could get features of an image by calling `FeatureExtractor.infer()`, and feed the features to KNNClassifier to classify an image.
 
-You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](https://github.com/ml5js/ml5-examples/tree/release/p5js/KNNClassification/KNNClassification_PoseNet
-
-) that uses KNNClassifier to classify data from [PoseNet](https://ml5js.org/reference/api-PoseNet/) model.
+You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_PoseNet) that uses KNNClassifier to classify data from [PoseNet](https://ml5js.org/reference/api-PoseNet/) model.
 
 ## Example
 
@@ -229,7 +227,7 @@ knnClassifier.classify(features, function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/master/p5js/KNNClassification/KNNClassification_Video) is a complete example to create a customizable classifier on live webcam images.
+[Here](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/KNNClassification/KNNClassification_Video) is a complete example to create a customizable classifier on live webcam images.
 
 ## Syntax
 

--- a/docs/reference/api-ObjectDetector.md
+++ b/docs/reference/api-ObjectDetector.md
@@ -12,7 +12,7 @@ order: 10
 
 examples:
   - title: Image Classification (Coco Ssd)
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
     demo: https://ml5js.github.io/ml5-examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
     code: >-
         // Create a cocoSsd classifier
@@ -109,7 +109,7 @@ objectDetector.detect(function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/ObjectDetector) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/ObjectDetector) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-PitchDetection.md
+++ b/docs/reference/api-PitchDetection.md
@@ -11,7 +11,7 @@ order: 1
 
 examples:
   - title: Pitch Detection
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PitchDetection/PitchDetection
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PitchDetection/PitchDetection
     demo: https://ml5js.github.io/ml5-examples/p5js/PitchDetection/PitchDetection
     code: >-
       let audioContext;
@@ -75,7 +75,7 @@ pitch.getPitch(function(err, frequency) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/PitchDetection/PitchDetection_Game/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js) is a complete example.
 
 ## Constructor
 

--- a/docs/reference/api-Pix2Pix.md
+++ b/docs/reference/api-Pix2Pix.md
@@ -10,7 +10,7 @@ order: 5
 
 examples:
   - title: Pix2Pix with Callbacks
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Pix2Pix/Pix2Pix_callback
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Pix2Pix/Pix2Pix_callback
     demo: https://ml5js.github.io/ml5-examples/p5js/Pix2Pix/Pix2Pix_callback
     code: >
       // Pix2pix Edges2Pikachu example with p5.js using callback functions
@@ -151,7 +151,7 @@ pix2pix.transfer(canvas, function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/Pix2Pix/Pix2Pix_callback/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/Pix2Pix/Pix2Pix_callback/sketch.js) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-PoseNet.md
+++ b/docs/reference/api-PoseNet.md
@@ -12,7 +12,7 @@ order: 1
 
 examples:
   - title: PoseNet on Image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_image_single
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_image_single
     demo: https://ml5js.github.io/ml5-examples/p5js/PoseNet/PoseNet_image_single
     code: >-
       let img;
@@ -108,7 +108,7 @@ examples:
       }
 
   - title: Posenet on Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_webcam
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_webcam
     demo: https://ml5js.github.io/ml5-examples/p5js/PoseNet/PoseNet_webcam
     code: >-
      see source code for details
@@ -141,7 +141,7 @@ poseNet.on("pose", function(results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_webcam) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/PoseNet/PoseNet_webcam) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-Sentiment.md
+++ b/docs/reference/api-Sentiment.md
@@ -11,7 +11,7 @@ order: 1
 
 examples:
   - title: Sentiment Analysis trained on movie reviews
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Sentiment
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Sentiment
     demo: https://ml5js.github.io/ml5-examples/p5js/Sentiment
     code: >-
       let sentiment;

--- a/docs/reference/api-SketchRNN.md
+++ b/docs/reference/api-SketchRNN.md
@@ -12,7 +12,7 @@ order: 8
 
 examples:
   - title: SketchRNN Basic
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/SketchRNN/SketchRNN_basic
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SketchRNN/SketchRNN_basic
     demo: https://ml5js.github.io/ml5-examples/p5js/SketchRNN/SketchRNN_basic
     code: >-
       // The SketchRNN model
@@ -124,7 +124,7 @@ function gotSketch(err, result) {
 }
 ```
 
-Here is [a complete example](https://github.com/ml5js/ml5-examples/tree/release/p5js/SketchRNN/SketchRNN_basic).
+Here is [a complete example](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SketchRNN/SketchRNN_basic).
 
 ## Syntax
 

--- a/docs/reference/api-StyleTransfer.md
+++ b/docs/reference/api-StyleTransfer.md
@@ -12,7 +12,7 @@ order: 4
 
 examples:
   - title: Style Transfer on Image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/StyleTransfer/StyleTransfer_Image
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/StyleTransfer/StyleTransfer_Image
     demo: https://ml5js.github.io/ml5-examples/p5js/StyleTransfer/StyleTransfer_Image
     code: >-
       // This uses a pre-trained model of The Great Wave off Kanagawa and Udnie (Young American Girl, The Dance)
@@ -93,7 +93,7 @@ style.transfer(document.getElementById("img"), function(err, resultImg) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/StyleTransfer/StyleTransfer_Image/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/StyleTransfer/StyleTransfer_Image/sketch.js) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-UNET.md
+++ b/docs/reference/api-UNET.md
@@ -12,7 +12,7 @@ order: 3
 
 examples:
   - title: UNET On Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/UNET/UNET_webcam
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/UNET/UNET_webcam
     demo: https://ml5js.github.io/ml5-examples/p5js/UNET/UNET_webcam/
     code: >-
       let video;

--- a/docs/reference/api-Word2vec.md
+++ b/docs/reference/api-Word2vec.md
@@ -11,7 +11,7 @@ order: 2
 
 examples:
   - title: Word2Vec Demo
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Word2Vec
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Word2Vec
     demo: https://ml5js.github.io/ml5-examples/p5js/Word2Vec
     code: >-
       let word2Vec;
@@ -82,7 +82,7 @@ examples:
 
 Word2vec is a group of related models that are used to produce [word embeddings](https://en.wikipedia.org/wiki/Word2vec)</sup>. This method allows you to perform vector operations on a given set of input vectors.
 
-You can use the word models [we provide](https://github.com/ml5js/ml5-examples/tree/master/p5js/Word2Vec/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/training-word2vec). More of this soon!
+You can use the word models [we provide](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/Word2Vec/Word2Vec_Interactive/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/training-word2vec). More of this soon!
 
 ### Example
 
@@ -101,7 +101,7 @@ wordVectors.nearest("rainbow", function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/Word2Vec/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/development/examples/p5js/Word2Vec/Word2Vec_Interactive/sketch.js) is a complete example.
 
 ## Constructor
 

--- a/docs/reference/api-YOLO.md
+++ b/docs/reference/api-YOLO.md
@@ -14,7 +14,7 @@ order: 9
 
 examples:
   - title: YOLO Image Classification
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/YOLO/YOLO_single_image
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/YOLO/YOLO_single_image
     demo: https://ml5js.github.io/ml5-examples/p5js/YOLO/YOLO_single_image
     code: >-
       const yolo = ml5.YOLO(modelReady);
@@ -102,7 +102,7 @@ yolo.detect(function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/YOLO) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/YOLO/YOLO_single_image) is a complete example.
 
 ## Syntax
 

--- a/docs/reference/api-charRNN.md
+++ b/docs/reference/api-charRNN.md
@@ -17,7 +17,7 @@ description: >-
 
 examples:
   - title: CharRNN Text Generator Example
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/CharRNN/CharRNN_Text
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CharRNN/CharRNN_Text
     demo: https://ml5js.github.io/ml5-examples/p5js/CharRNN/CharRNN_Text
     code: >-
       // LSTM Generator example with p5.js
@@ -121,7 +121,7 @@ rnn.generate({ seed: "the meaning of pizza is" }, function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/CharRNN/CharRNN_Text) is a complete example using the [p5.js](https://p5js.org) library.
+[Here](https://github.com/ml5js/ml5-library/tree/development/examples/p5js/CharRNN/CharRNN_Text) is a complete example using the [p5.js](https://p5js.org) library.
 
 ## Syntax
 

--- a/docs/reference/api-soundClassifier.md
+++ b/docs/reference/api-soundClassifier.md
@@ -11,7 +11,7 @@ order: 0
 
 examples:
   - title: SoundClassifier "SpeechCommands18w"
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/SoundClassification/SoundClassification_speechcommand
+    github: https://github.com/ml5js/ml5-library/tree/development/examples/p5js/SoundClassification/SoundClassification_speechcommand
     demo: https://ml5js.github.io/ml5-examples/p5js/SoundClassification/SoundClassification_speechcommand/
     code: >-
       // Initialize a sound classifier method with SpeechCommands18w model. A callback needs to be passed.

--- a/docs/reference/example.md
+++ b/docs/reference/example.md
@@ -15,7 +15,7 @@ description: >-
 
 examples:
   - title: the title of the demo
-    github: https://github.com/ml5js/ml5-examples/blob/release/javascript/ImageClassification_Video/sketch.js
+    github: https://github.com/ml5js/ml5-library/blob/development/examples/p5js/ImageClassification/ImageClassification_Video/sketch.js
     demo: https://yining1023.github.io/fast_style_transfer_in_ML5/
     code: >-
       const video = document.getElementById("video");
@@ -34,7 +34,7 @@ examples:
       });
 
   - title: the title of the demo
-    github: https://github.com/ml5js/ml5-examples/blob/release/javascript/ImageClassification_Video/sketch.js
+    github: https://github.com/ml5js/ml5-library/blob/development/examples/p5js/ImageClassification/ImageClassification_Video/sketch.js
     demo: https://yining1023.github.io/fast_style_transfer_in_ML5/
     code: >-
       const video = document.getElementById("video");


### PR DESCRIPTION
Howdy!

**What kind of change does this PR introduce?**

This pull request updates references to the archived `ml5-examples` repository. It complements [#993](https://github.com/ml5js/ml5-library/pull/993) from `ml5-library`.

**Does this PR introduce a breaking change?**

Nope–works on my machine!

**What needs to be documented once your changes are merged?**

None, as far as I can tell.