### PR TITLE
Fix links going to the documentation pages

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -9,5 +9,5 @@ draft: false
 
 Hello! We are currently updating our website. <br/><br/>
 
-The latest documentation on Getting Started with ml5 can be found here: [ml5 getting started documentation](https://ml5js.github.io/ml5-library/docs/#/)
+The latest documentation on Getting Started with ml5 can be found here: [ml5 getting started documentation](https://learn.ml5js.org/#/)
  

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -65,14 +65,14 @@ const Navbar = class extends React.Component {
               <a
                 className="Navbar__item"
                 activeclassname="is-active"
-                href="https://ml5js.github.io/ml5-library/docs/#/"
+                href="https://learn.ml5js.org/"
               >
                 Getting Started
               </a>
               <a
                 className="Navbar__item"
                 activeclassname="is-active"
-                href="https://ml5js.github.io/ml5-library/docs/#/reference/index"
+                href="https://learn.ml5js.org/#/reference/index"
               >
                 Reference
               </a>

--- a/src/pages/reference/index.js
+++ b/src/pages/reference/index.js
@@ -22,7 +22,7 @@ export default class ReferenceIndexPage extends React.Component {
               <div className="reference__wrapper">
                 {/* <ModelListCards /> */}
                 <p>Hello! We are currently updating our website.</p>
-                <p>The latest documentation on Getting Started with ml5 can be found here: <a href="https://ml5js.github.io/ml5-library/docs/#/reference/index">ml5 references</a></p>
+                <p>The latest documentation on Getting Started with ml5 can be found here: <a href="https://learn.ml5js.org/#/reference/index">ml5 references</a></p>
               </div>
             </article>
           </div>


### PR DESCRIPTION
Fixes issues associated with the Netlify transition (I didn't realize we also had so many references to the Github pages base URL in this codebase). This PR has some small fixes for the links!