### PR TITLE
Fix broken footer links

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -29,12 +29,12 @@ const Footer = class extends React.Component {
                     </span>
                   </li>
                   <li>
-                    <a className="Footer__item" href="https://learn.ml5js.org/docs/#/">
+                    <a className="Footer__item" href="https://learn.ml5js.org">
                       Getting Started
                     </a>
                   </li>
                   <li>
-                    <a className="Footer__item" href="https://learn.ml5js.org/docs/#/reference/index">
+                    <a className="Footer__item" href="https://learn.ml5js.org/#/reference/index">
                       API Reference
                     </a>
                   </li>


### PR DESCRIPTION
The "Getting Started" and "API Reference" links at the bottom of the ml5js.org homepage were giving 404s:

![image](https://user-images.githubusercontent.com/1167575/96075696-57579280-0ef7-11eb-866b-ae674883fd4e.png)
