### PR TITLE
Update links to point main branch of ml5-library & remove references to ml5-examples

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -68,7 +68,7 @@ We like these hashtags: #noCodeSnobs (because we value community over efficiency
 <br/>
 Our community is always looking for enthusiasts to help in all different ways. 
 
-> - · **Develop**. [GitHub](https://github.com/ml5js/ml5-library) is the main place where code is collected, issues are documented, and discussions about code are had. Check out the [contributing documentation to get started](https://github.com/ml5js/ml5-library/blob/development/CONTRIBUTING.md) with developing the library.
+> - · **Develop**. [GitHub](https://github.com/ml5js/ml5-library) is the main place where code is collected, issues are documented, and discussions about code are had. Check out the [contributing documentation to get started](https://github.com/ml5js/ml5-library/blob/main/CONTRIBUTING.md) with developing the library.
 > - · **Document**. Everyone loves documentation. Help is needed porting examples, and adding documentation, and creating tutorials.
 > - · **Teach**. Teach a workshop, a class, a friend, a collaborator! Tag [@ml5js on Twitter](https://twitter.com/ml5js?lang=en) and we will do our best to share what you're doing.
 > - · **Create**. ml5.js is looking for designers, artists, coders, programmers to bring your creative and amazing work to show and inspire other people. Submit your work to info@ml5js.org.

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -34,4 +34,4 @@ draft: false
 
 ### How can I contribute?
 
-> Please refer to the contributor documentation [on Github](https://github.com/ml5js/ml5-library/blob/development/CONTRIBUTING.md).
+> Please refer to the contributor documentation [on Github](https://github.com/ml5js/ml5-library/blob/main/CONTRIBUTING.md).

--- a/docs/getting-started/hello-ml5.md
+++ b/docs/getting-started/hello-ml5.md
@@ -50,7 +50,7 @@ Your project directory should look something like this:
 
 ## Demo
 
-This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-examples/tree/release/javascript/ImageClassification).
+This example is built with p5.js. You can also find the same example without p5.js [here](https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification).
 
 <br/>
 
@@ -61,7 +61,7 @@ This example is built with p5.js. You can also find the same example without p5.
 </div> -->
 
 <!-- added inline height -->
-<div style="height:600px" class="iframe__container iframe__container--video"><iframe src="https://ml5js.github.io/ml5-examples/p5js/ImageClassification/ImageClassification" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+<div style="height:600px" class="iframe__container iframe__container--video"><iframe src="https://examples.ml5js.org/p5js/ImageClassification/ImageClassification" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 ## Code
 
@@ -207,7 +207,7 @@ Some guiding questions you might start to think about are:
 1. When classifying an image with MobileNet, does the computer see people? If not, why do you think that is?
 2. Do you notice that MobileNet is better at classifying some animals over others? Why do you think that is?
 
-## [Source](https://github.com/ml5js/ml5-examples/tree/master/p5js/ImageClassification/ImageClassification)
+## [Source](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification)
 
-- [ml5.js image classification on Github](https://github.com/ml5js/ml5-examples/tree/master/p5js/ImageClassification/ImageClassification)
+- [ml5.js image classification on Github](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification)
 - [ml5.js image classification on p5 web editor](https://editor.p5js.org/ml5/sketches/ImageClassification)

--- a/docs/getting-started/running-examples.md
+++ b/docs/getting-started/running-examples.md
@@ -12,38 +12,10 @@ If you've looked at our [quickstart](/getting-started/) and [introduction to ml5
 
 <br/>
 
-A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples at out Github page: [ml5-examples](https://github.com/ml5js/ml5-examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them. 
+A big part of the ml5 project is to create lots of examples as launching points for all your creative project ideas. You can find all of the ml5.js examples in the `examples/` directory in the [ml5-library GitHub repository](https://github.com/ml5js/ml5-library/tree/main/examples). If you start to explore these examples you can see how the different ml5 functions are used to accomplish different outcomes. We try our best to keep the examples as simple as possible so you can easily start to build your ideas on top of them. 
 
 You can check out all the examples running:
-> - [on this massive list](https://github.com/ml5js/ml5-examples#examples-index)
+> - [on this massive list](https://examples.ml5js.org/)
 > - [on the p5 web editor](https://editor.p5js.org/ml5/sketches)
 
-If you'd like to download the examples and run them locally, download the [ml5-examples github repo](https://github.com/ml5js/ml5-examples) and run a local web server at the root directory (if this sentence sounds foreign to you, see the How-To section below). The fastest way to do this is:
-
-<br/>
-
-with **python3** installed on your computer:
-```bash
-cd /path/to/ml5-examples
-python -m http.server 8081
-```
-
-<br/>
-
-with **python2.7** installed on your computer:
-
-```bash
-cd /path/to/ml5-examples
-python -m SimpleHTTPServer 8081
-```
-
-Then open up your web browser to the url: **localhost:8081** 
-
-<br/>
-
-Here we set the port number to **8081**, but you can change the port number to something else like **3000** (then: **localhost:3030**), **3001** (then: **localhost:3031**) for example. 
-
-
-## How to: Run examples and develop "locally"
-
-Coming soon! In the meantime, you can watch [CodingTrain - getting set up](https://www.youtube.com/watch?v=UCHzlUiDD10) for a nice intro on getting set up with writing code for the web.
+If you'd like to download the examples and run them locally, download the [ml5-library GitHub repo](https://github.com/ml5js/ml5-library) and use the `npm run develop` terminal command from the root directory of the ml5-library folder. Please see further documentation on this process on the [ml5-library repository](https://github.com/ml5js/ml5-library/blob/main/examples/README.md)! Additionally, you can watch [CodingTrain - getting set up](https://www.youtube.com/watch?v=UCHzlUiDD10) for a nice intro on getting set up with writing code for the web.

--- a/docs/reference/api-BodyPix.md
+++ b/docs/reference/api-BodyPix.md
@@ -11,8 +11,8 @@ order: 2
 
 examples:
   - title: BodyPix Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/BodyPix
-    demo: https://ml5js.github.io/ml5-examples/p5js/BodyPix/BodyPix_Webcam/
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/BodyPix
+    demo: https://examples.ml5js.org/p5js/BodyPix/BodyPix_Webcam/
     code: >-
       let bodypix;
       let video;
@@ -243,4 +243,4 @@ ml5.bodyPix(?video, ?options, ?callback)
 
 ## Source
 
-[/src/BodyPix/](https://github.com/ml5js/ml5-library/tree/release/src/BodyPix)
+[/src/BodyPix/](https://github.com/ml5js/ml5-library/tree/main/src/BodyPix)

--- a/docs/reference/api-CVAE.md
+++ b/docs/reference/api-CVAE.md
@@ -11,8 +11,8 @@ order: 6
 
 examples:
   - title: CVAE using Quickdraw dataset
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/CVAE
-    demo: https://ml5js.github.io/ml5-examples/p5js/CVAE/
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CVAE
+    demo: https://examples.ml5js.org/p5js/CVAE/
     code: >-
       let cvae;
       let button;
@@ -109,4 +109,4 @@ ml5.CVAE(?model, ?callback)
 
 ## Source
 
-[/src/CVAE/](https://github.com/ml5js/ml5-library/tree/release/src/CVAE)
+[/src/CVAE/](https://github.com/ml5js/ml5-library/tree/main/src/CVAE)

--- a/docs/reference/api-DCGAN.md
+++ b/docs/reference/api-DCGAN.md
@@ -11,8 +11,8 @@ order: 7
 
 examples:
   - title: DCGAN - generated lo-res aerial images
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/DCGAN
-    demo: https://ml5js.github.io/ml5-examples/p5js/DCGAN/
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/DCGAN
+    demo: https://examples.ml5js.org/p5js/DCGAN/
     code: >-
       let dcgan;
       let button;
@@ -130,4 +130,4 @@ ml5.DCGAN(?modelPath, ?callback)
 
 ## Source
 
-[/src/DCGAN/](https://github.com/ml5js/ml5-library/tree/release/src/DCGAN)
+[/src/DCGAN/](https://github.com/ml5js/ml5-library/tree/main/src/DCGAN)

--- a/docs/reference/api-FeatureExtractor.md
+++ b/docs/reference/api-FeatureExtractor.md
@@ -16,8 +16,8 @@ description: >-
 
 examples:
   - title: Feature Extractor for Image Classification
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
-    demo: https://ml5js.github.io/ml5-examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
+    demo: https://examples.ml5js.org/p5js/FeatureExtractor/FeatureExtractor_Image_Classification
     code: >-  
       let featureExtractor;
       let classifier;
@@ -165,9 +165,9 @@ classifier.classify(document.getElementById("dogB"), function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js) is a complete example to create a custom regression.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js) is a complete example to create a custom regression.
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js) is a complete example to create a custom classifier.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js) is a complete example to create a custom classifier.
 
 ### Syntax
 
@@ -294,4 +294,4 @@ Boolean value to check if the model is predicting.
 
 ### Source
 
-[src/FeatureExtractor](https://github.com/ml5js/ml5-library/tree/release/src/FeatureExtractor)
+[src/FeatureExtractor](https://github.com/ml5js/ml5-library/tree/main/src/FeatureExtractor)

--- a/docs/reference/api-ImageClassifier.md
+++ b/docs/reference/api-ImageClassifier.md
@@ -14,8 +14,8 @@ order: 0
 
 examples:
   - title: Image classifier on image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ImageClassification/ImageClassification
-    demo: https://ml5js.github.io/ml5-examples/p5js/ImageClassification/ImageClassification
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification
+    demo: https://examples.ml5js.org/p5js/ImageClassification/ImageClassification
     code: >-
       // Initialize the Image Classifier method with MobileNet. A callback needs to be passed.
       
@@ -50,8 +50,8 @@ examples:
       }
 
   - title: Image classifier on video
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ImageClassification/ImageClassification_Video
-    demo: https://ml5js.github.io/ml5-examples/p5js/ImageClassification/ImageClassification_Video
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ImageClassification/ImageClassification_Video
+    demo: https://examples.ml5js.org/p5js/ImageClassification/ImageClassification_Video
     code: >-
       let classifier;
       let video;
@@ -112,7 +112,7 @@ classifier.predict(document.getElementById('image'), function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/ImageClassification/ImageClassification/sketch.js) is a complete example using the [p5.js](https://p5js.org/) library for loading and displaying the image.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/ImageClassification/ImageClassification/sketch.js) is a complete example using the [p5.js](https://p5js.org/) library for loading and displaying the image.
 
 ## Syntax
   ```javascript
@@ -184,4 +184,4 @@ classifier.predict(document.getElementById('image'), function(err, results) {
 
 ## Source
 
-[/src/ImageClassifier](https://github.com/ml5js/ml5-library/tree/release/src/ImageClassifier)
+[/src/ImageClassifier](https://github.com/ml5js/ml5-library/tree/main/src/ImageClassifier)

--- a/docs/reference/api-KNNClassifier.md
+++ b/docs/reference/api-KNNClassifier.md
@@ -11,8 +11,8 @@ order: 1
 
 examples:
   - title: KNN Classfication on video
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/KNNClassification/KNNClassification_Video
-    demo: https://ml5js.github.io/ml5-examples/p5js/KNNClassification/KNNClassification_Video
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_Video
+    demo: https://examples.ml5js.org/p5js/KNNClassification/KNNClassification_Video
     code: >-
       let video;
       // Create a KNN classifier
@@ -202,7 +202,7 @@ This class allows you to create a classifier using the [K-Nearest Neighbors](htt
 
 For example, you could get features of an image by calling `FeatureExtractor.infer()`, and feed the features to KNNClassifier to classify an image.
 
-You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](https://github.com/ml5js/ml5-examples/tree/release/p5js/KNNClassification/KNNClassification_PoseNet
+You can also collect any kind of data, construct them into an array of numbers and feed them to KNNClassifier. Check out this [example](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_PoseNet
 
 ) that uses KNNClassifier to classify data from [PoseNet](https://ml5js.org/reference/api-PoseNet/) model.
 
@@ -229,7 +229,7 @@ knnClassifier.classify(features, function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/master/p5js/KNNClassification/KNNClassification_Video) is a complete example to create a customizable classifier on live webcam images.
+[Here](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/KNNClassification/KNNClassification_Video) is a complete example to create a customizable classifier on live webcam images.
 
 ## Syntax
 
@@ -316,4 +316,4 @@ ml5.KNNClassifier();
 
 ## Source
 
-[/src/KNNClassifier/](https://github.com/ml5js/ml5-library/tree/release/src/KNNClassifier)
+[/src/KNNClassifier/](https://github.com/ml5js/ml5-library/tree/main/src/KNNClassifier)

--- a/docs/reference/api-ObjectDetector.md
+++ b/docs/reference/api-ObjectDetector.md
@@ -12,8 +12,8 @@ order: 10
 
 examples:
   - title: Image Classification (Coco Ssd)
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
-    demo: https://ml5js.github.io/ml5-examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
+    demo: https://examples.ml5js.org/p5js/ObjectDetector/ObjectDetector_COCOSSD_single_image
     code: >-
         // Create a cocoSsd classifier
 
@@ -109,7 +109,7 @@ objectDetector.detect(function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/ObjectDetector) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/ObjectDetector) is a complete example.
 
 ## Syntax
 
@@ -167,4 +167,4 @@ objectDetector.detect(?callback)
 
 ## Source
 
-[/src/ObjectDetector](https://github.com/ml5js/ml5-library/tree/release/src/ObjectDetector)
+[/src/ObjectDetector](https://github.com/ml5js/ml5-library/tree/main/src/ObjectDetector)

--- a/docs/reference/api-PitchDetection.md
+++ b/docs/reference/api-PitchDetection.md
@@ -11,8 +11,8 @@ order: 1
 
 examples:
   - title: Pitch Detection
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PitchDetection/PitchDetection
-    demo: https://ml5js.github.io/ml5-examples/p5js/PitchDetection/PitchDetection
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PitchDetection/PitchDetection
+    demo: https://examples.ml5js.org/p5js/PitchDetection/PitchDetection
     code: >-
       let audioContext;
       let mic;
@@ -75,7 +75,7 @@ pitch.getPitch(function(err, frequency) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/PitchDetection/PitchDetection_Game/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/PitchDetection/PitchDetection_Game/sketch.js) is a complete example.
 
 ## Constructor
 
@@ -114,4 +114,4 @@ ml5.pitchDetection(model, audioContext, stream, callback);
 
 ## Source
 
-[/src/PitchDetection](https://github.com/ml5js/ml5-library/tree/release/src/PitchDetection)
+[/src/PitchDetection](https://github.com/ml5js/ml5-library/tree/main/src/PitchDetection)

--- a/docs/reference/api-Pix2Pix.md
+++ b/docs/reference/api-Pix2Pix.md
@@ -10,8 +10,8 @@ order: 5
 
 examples:
   - title: Pix2Pix with Callbacks
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Pix2Pix/Pix2Pix_callback
-    demo: https://ml5js.github.io/ml5-examples/p5js/Pix2Pix/Pix2Pix_callback
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Pix2Pix/Pix2Pix_callback
+    demo: https://examples.ml5js.org/p5js/Pix2Pix/Pix2Pix_callback
     code: >
       // Pix2pix Edges2Pikachu example with p5.js using callback functions
       // This uses a pre-trained model on Pikachu images
@@ -151,7 +151,7 @@ pix2pix.transfer(canvas, function(err, result) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/Pix2Pix/Pix2Pix_callback/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/Pix2Pix/Pix2Pix_callback/sketch.js) is a complete example.
 
 ## Syntax
 
@@ -186,4 +186,4 @@ ml5.pix2pix(model, ?callback);
 
 ## Source
 
-[/src/Pix2pix](https://github.com/ml5js/ml5-library/tree/release/src/Pix2pix)
+[/src/Pix2pix](https://github.com/ml5js/ml5-library/tree/main/src/Pix2pix)

--- a/docs/reference/api-PoseNet.md
+++ b/docs/reference/api-PoseNet.md
@@ -12,8 +12,8 @@ order: 1
 
 examples:
   - title: PoseNet on Image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_image_single
-    demo: https://ml5js.github.io/ml5-examples/p5js/PoseNet/PoseNet_image_single
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_image_single
+    demo: https://examples.ml5js.org/p5js/PoseNet/PoseNet_image_single
     code: >-
       let img;
       let poseNet;
@@ -108,8 +108,8 @@ examples:
       }
 
   - title: Posenet on Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_webcam
-    demo: https://ml5js.github.io/ml5-examples/p5js/PoseNet/PoseNet_webcam
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_webcam
+    demo: https://examples.ml5js.org/p5js/PoseNet/PoseNet_webcam
     code: >-
      see source code for details
 
@@ -141,7 +141,7 @@ poseNet.on("pose", function(results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/PoseNet/PoseNet_webcam) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/PoseNet/PoseNet_webcam) is a complete example.
 
 ## Syntax
 
@@ -263,4 +263,4 @@ For more details about the poseNet outputs, read more [here](https://github.com/
 
 ## Source
 
-[/src/PoseNet](https://github.com/ml5js/ml5-library/tree/release/src/PoseNet)
+[/src/PoseNet](https://github.com/ml5js/ml5-library/tree/main/src/PoseNet)

--- a/docs/reference/api-Sentiment.md
+++ b/docs/reference/api-Sentiment.md
@@ -11,8 +11,8 @@ order: 1
 
 examples:
   - title: Sentiment Analysis trained on movie reviews
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Sentiment
-    demo: https://ml5js.github.io/ml5-examples/p5js/Sentiment
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Sentiment
+    demo: https://examples.ml5js.org/p5js/Sentiment
     code: >-
       let sentiment;
       let statusEl;
@@ -116,4 +116,4 @@ currently the supported model name is 'moviereviews'. ml5 may support different 
 
 ## Source
 
-[/src/Sentiment/](https://github.com/ml5js/ml5-library/tree/release/src/Sentiment)
+[/src/Sentiment/](https://github.com/ml5js/ml5-library/tree/main/src/Sentiment)

--- a/docs/reference/api-SketchRNN.md
+++ b/docs/reference/api-SketchRNN.md
@@ -12,8 +12,8 @@ order: 8
 
 examples:
   - title: SketchRNN Basic
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/SketchRNN/SketchRNN_basic
-    demo: https://ml5js.github.io/ml5-examples/p5js/SketchRNN/SketchRNN_basic
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SketchRNN/SketchRNN_basic
+    demo: https://examples.ml5js.org/p5js/SketchRNN/SketchRNN_basic
     code: >-
       // The SketchRNN model
 
@@ -124,7 +124,7 @@ function gotSketch(err, result) {
 }
 ```
 
-Here is [a complete example](https://github.com/ml5js/ml5-examples/tree/release/p5js/SketchRNN/SketchRNN_basic).
+Here is [a complete example](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SketchRNN/SketchRNN_basic).
 
 ## Syntax
 
@@ -168,4 +168,4 @@ ml5.SketchRNN(model, ?callback)
 
 ## Source
 
-[/src/SketchRNN/](https://github.com/ml5js/ml5-library/tree/release/src/SketchRNN)
+[/src/SketchRNN/](https://github.com/ml5js/ml5-library/tree/main/src/SketchRNN)

--- a/docs/reference/api-StyleTransfer.md
+++ b/docs/reference/api-StyleTransfer.md
@@ -12,8 +12,8 @@ order: 4
 
 examples:
   - title: Style Transfer on Image
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/StyleTransfer/StyleTransfer_Image
-    demo: https://ml5js.github.io/ml5-examples/p5js/StyleTransfer/StyleTransfer_Image
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/StyleTransfer/StyleTransfer_Image
+    demo: https://examples.ml5js.org/p5js/StyleTransfer/StyleTransfer_Image
     code: >-
       // This uses a pre-trained model of The Great Wave off Kanagawa and Udnie (Young American Girl, The Dance)
 
@@ -93,7 +93,7 @@ style.transfer(document.getElementById("img"), function(err, resultImg) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/StyleTransfer/StyleTransfer_Image/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/StyleTransfer/StyleTransfer_Image/sketch.js) is a complete example.
 
 ## Syntax
 
@@ -139,4 +139,4 @@ ml5.styleTransfer(model, ?video, ?callback)
 
 ## Source
 
-[/src/StyleTransfer/](https://github.com/ml5js/ml5-library/tree/release/src/StyleTransfer)
+[/src/StyleTransfer/](https://github.com/ml5js/ml5-library/tree/main/src/StyleTransfer)

--- a/docs/reference/api-UNET.md
+++ b/docs/reference/api-UNET.md
@@ -12,8 +12,8 @@ order: 3
 
 examples:
   - title: UNET On Webcam
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/UNET/UNET_webcam
-    demo: https://ml5js.github.io/ml5-examples/p5js/UNET/UNET_webcam/
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/UNET/UNET_webcam
+    demo: https://examples.ml5js.org/p5js/UNET/UNET_webcam/
     code: >-
       let video;
       let uNet;
@@ -125,5 +125,5 @@ ml5.uNet(model, ?callback)
 
 ## Source
 
-[/src/UNET/](https://github.com/ml5js/ml5-library/tree/release/src/UNET)
+[/src/UNET/](https://github.com/ml5js/ml5-library/tree/main/src/UNET)
 

--- a/docs/reference/api-Word2vec.md
+++ b/docs/reference/api-Word2vec.md
@@ -11,8 +11,8 @@ order: 2
 
 examples:
   - title: Word2Vec Demo
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/Word2Vec
-    demo: https://ml5js.github.io/ml5-examples/p5js/Word2Vec
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Word2Vec
+    demo: https://examples.ml5js.org/p5js/Word2Vec
     code: >-
       let word2Vec;
 
@@ -82,7 +82,7 @@ examples:
 
 Word2vec is a group of related models that are used to produce [word embeddings](https://en.wikipedia.org/wiki/Word2vec)</sup>. This method allows you to perform vector operations on a given set of input vectors.
 
-You can use the word models [we provide](https://github.com/ml5js/ml5-examples/tree/master/p5js/Word2Vec/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/training-word2vec). More of this soon!
+You can use the word models [we provide](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/Word2Vec/data), trained on a corpus of english words (watch out for bias data!), or you can train your own vector models following [this tutorial](https://github.com/ml5js/training-word2vec). More of this soon!
 
 ### Example
 
@@ -101,7 +101,7 @@ wordVectors.nearest("rainbow", function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/blob/master/p5js/Word2Vec/sketch.js) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/blob/main/examples/p5js/Word2Vec/sketch.js) is a complete example.
 
 ## Constructor
 
@@ -188,4 +188,4 @@ Word2Vec(model, ?callback)
 
 ## Source
 
-[/src/Word2vec/](https://github.com/ml5js/ml5-library/tree/release/src/Word2vec)
+[/src/Word2vec/](https://github.com/ml5js/ml5-library/tree/main/src/Word2vec)

--- a/docs/reference/api-YOLO.md
+++ b/docs/reference/api-YOLO.md
@@ -14,8 +14,8 @@ order: 9
 
 examples:
   - title: YOLO Image Classification
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/YOLO/YOLO_single_image
-    demo: https://ml5js.github.io/ml5-examples/p5js/YOLO/YOLO_single_image
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/YOLO/YOLO_single_image
+    demo: https://examples.ml5js.org/p5js/YOLO/YOLO_single_image
     code: >-
       const yolo = ml5.YOLO(modelReady);
       let img;
@@ -102,7 +102,7 @@ yolo.detect(function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/YOLO) is a complete example.
+[Here](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/YOLO) is a complete example.
 
 ## Syntax
 
@@ -159,4 +159,4 @@ ml5.YOLO(?options, ?callback)
 
 ## Source
 
-[/src/YOLO](https://github.com/ml5js/ml5-library/tree/release/src/YOLO)
+[/src/YOLO](https://github.com/ml5js/ml5-library/tree/main/src/YOLO)

--- a/docs/reference/api-charRNN.md
+++ b/docs/reference/api-charRNN.md
@@ -17,8 +17,8 @@ description: >-
 
 examples:
   - title: CharRNN Text Generator Example
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/CharRNN/CharRNN_Text
-    demo: https://ml5js.github.io/ml5-examples/p5js/CharRNN/CharRNN_Text
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CharRNN/CharRNN_Text
+    demo: https://examples.ml5js.org/p5js/CharRNN/CharRNN_Text
     code: >-
       // LSTM Generator example with p5.js
       // This uses a pre-trained model on a corpus of Virginia Woolf
@@ -121,7 +121,7 @@ rnn.generate({ seed: "the meaning of pizza is" }, function(err, results) {
 });
 ```
 
-[Here](https://github.com/ml5js/ml5-examples/tree/release/p5js/CharRNN/CharRNN_Text) is a complete example using the [p5.js](https://p5js.org) library.
+[Here](https://github.com/ml5js/ml5-library/tree/main/examples/p5js/CharRNN/CharRNN_Text) is a complete example using the [p5.js](https://p5js.org) library.
 
 ## Syntax
 
@@ -188,4 +188,4 @@ The vocabulary size (or total number of possible characters).
 
 ### Source
 
-[/src/charRNN/](https://github.com/ml5js/ml5-library/tree/release/src/CharRNN)
+[/src/charRNN/](https://github.com/ml5js/ml5-library/tree/main/src/CharRNN)

--- a/docs/reference/api-soundClassifier.md
+++ b/docs/reference/api-soundClassifier.md
@@ -11,8 +11,8 @@ order: 0
 
 examples:
   - title: SoundClassifier "SpeechCommands18w"
-    github: https://github.com/ml5js/ml5-examples/tree/release/p5js/SoundClassification/SoundClassification_speechcommand
-    demo: https://ml5js.github.io/ml5-examples/p5js/SoundClassification/SoundClassification_speechcommand/
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/p5js/SoundClassification/SoundClassification_speechcommand
+    demo: https://examples.ml5js.org/p5js/SoundClassification/SoundClassification_speechcommand/
     code: >-
       // Initialize a sound classifier method with SpeechCommands18w model. A callback needs to be passed.
 
@@ -136,4 +136,4 @@ By default the soundClassifier will start the default microphone.
 
 ## Source
 
-[/src/SoundClassifier/](https://github.com/ml5js/ml5-library/tree/release/src/SoundClassifier)
+[/src/SoundClassifier/](https://github.com/ml5js/ml5-library/tree/main/src/SoundClassifier)

--- a/docs/reference/example.md
+++ b/docs/reference/example.md
@@ -15,7 +15,7 @@ description: >-
 
 examples:
   - title: the title of the demo
-    github: https://github.com/ml5js/ml5-examples/blob/release/javascript/ImageClassification_Video/sketch.js
+    github: https://github.com/ml5js/ml5-library/tree/main/examples/javascript/ImageClassification/ImageClassification_Video
     demo: https://yining1023.github.io/fast_style_transfer_in_ML5/
     code: >-
       const video = document.getElementById("video");
@@ -34,7 +34,7 @@ examples:
       });
 
   - title: the title of the demo
-    github: https://github.com/ml5js/ml5-examples/blob/release/javascript/ImageClassification_Video/sketch.js
+    github: https://github.com/ml5js/ml5-library/blob/main/examples/javascript/ImageClassification/ImageClassification_Video/sketch.js
     demo: https://yining1023.github.io/fast_style_transfer_in_ML5/
     code: >-
       const video = document.getElementById("video");


### PR DESCRIPTION
This PR has a few focuses:
- Removing references to the `release` and `development` branches in ml5-library, and point them to the new `main` branch will be our prevailing "source of truth" for the latest, released code in ml5.js after the release of 0.6.0. https://github.com/ml5js/ml5-library/issues/917
- Cleaning up all of the references to ml5-examples that were leftover from our archival of that repository. I accidentally forgot to clean these up after the transition.
- Replace references to https://ml5js.github.io/ml5-examples to https://examples.ml5js.org, so that these links aren't dependent on our GitHub pages hosting now that we've moved over to Netlify.
- I also made some small changes to the "Running Examples" docs to make note of the newer `npm run develop` command I added earlier this year.