### PR TITLE
Fix folder emphasised

### DIFF
--- a/docs/getting-started/hello-ml5.md
+++ b/docs/getting-started/hello-ml5.md
@@ -42,8 +42,8 @@ Your project directory should look something like this:
 
 **Where**:
 
-* 📂**/hello-ml5**: is the root project folder
-  * &ensp; 📂**/images**: is a folder that contains your image
+* 📂**hello-ml5/**: is the root project folder
+  * &ensp; 📂**images/**: is a folder that contains your image
     * &ensp; &ensp; &ensp; 🖼 **bird.png**: is a .png image of a bird (it can also be something else!)
   * &ensp; 🗒**index.html**: is an .html file that has your html markup and library references
   * &ensp; 🗒**sketch.js**: is where you'll be writing your javascript


### PR DESCRIPTION
For some reason, markdown doesn’t render **/text** as bold so the folders aren’t rendered*. 
Instead, I put the slash behind the name of the folder

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixing a bug in Markdown
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
Definitely not 🙃

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Edit:
*I just realised GitHub renders them right, nevertheless the Docs don’t:
![70E44740-0B2C-4E0C-A9CC-E1A7B26E1BDD](https://user-images.githubusercontent.com/67760881/118351943-feb8a880-b55e-11eb-8aee-f7b4f680c2b7.png)

https://learn.ml5js.org/#/tutorials/hello-ml5
